### PR TITLE
Refactor API version and locale handling in middleware

### DIFF
--- a/app/Framework/Factories/ApiResponseFactory.php
+++ b/app/Framework/Factories/ApiResponseFactory.php
@@ -9,9 +9,9 @@ use App\Framework\Services\ApiV2ResponseService;
 class ApiResponseFactory
 {
 
-    public static function make($path): ApiResponseContract
+    public static function make(): ApiResponseContract
     {
-        $version = explode('/', $path)[1] ?? 'v1';
+        $version = app('route.version');
 
         if (str_starts_with($version, 'v2')) {
             return new ApiV2ResponseService();

--- a/app/Framework/Middleware/SetLocale.php
+++ b/app/Framework/Middleware/SetLocale.php
@@ -13,6 +13,7 @@ class SetLocale
     public function handle(Request $request, Closure $next): Response
     {
         $locale = $request->route('lang');
+        App::instance('route.lang', $locale);
         $request->route()->forgetParameter('lang');
 
         if (!in_array($locale, ['en', 'es'])) {

--- a/app/Framework/Middleware/ValidateApiVersion.php
+++ b/app/Framework/Middleware/ValidateApiVersion.php
@@ -6,6 +6,7 @@ use App\Framework\Enums\HttpStatusCodes;
 use App\Framework\Facades\ApiResponse;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
 use Symfony\Component\HttpFoundation\Response;
 
 class ValidateApiVersion
@@ -17,6 +18,7 @@ class ValidateApiVersion
     public function handle(Request $request, Closure $next): Response
     {
         $version = $request->route('version');
+        App::instance('route.version', $version);
         $request->route()->forgetParameter('version');
 
         if (!in_array($version, $this->allowedVersions, true)) {

--- a/app/Framework/Providers/ApiServiceProvider.php
+++ b/app/Framework/Providers/ApiServiceProvider.php
@@ -17,16 +17,14 @@ class ApiServiceProvider extends ServiceProvider
         $this->app->singleton('tempTable', function () {
             return new TempTableService();
         });
+
+        $this->app->bind(ApiResponseContract::class, function () {
+            return ApiResponseFactory::make();
+        });
     }
 
     /**
      * Bootstrap services.
      */
-    public function boot(): void
-    {
-        $request = request()->path();
-        $this->app->bind(ApiResponseContract::class, function () use ($request) {
-            return ApiResponseFactory::make($request);
-        });
-    }
+    public function boot(): void {}
 }


### PR DESCRIPTION
API version and locale are now stored in the container via App::instance for easier access throughout the request lifecycle. ApiResponseFactory no longer requires a path parameter and instead retrieves the version from the container. Improved error handling in FormatApiResponse middleware to log and return a fallback response on failure. ApiServiceProvider updated to bind ApiResponseContract using the new factory signature.