### PR TITLE
Add fallback for API version in ApiResponseFactory

### DIFF
--- a/app/Framework/Factories/ApiResponseFactory.php
+++ b/app/Framework/Factories/ApiResponseFactory.php
@@ -11,7 +11,12 @@ class ApiResponseFactory
 
     public static function make(): ApiResponseContract
     {
-        $version = app('route.version');
+        try {
+            $version = app('app.api.version');
+        } catch (\Exception $e) {
+            // Fallback to default version if not set
+            $version = 'v1';
+        }
 
         if (str_starts_with($version, 'v2')) {
             return new ApiV2ResponseService();


### PR DESCRIPTION
ApiResponseFactory now attempts to retrieve the API version from 'app.api.version' and falls back to 'v1' if unavailable. This improves robustness when the version is not set in the application container.