### PR TITLE
Update container keys for locale and version middleware

### DIFF
--- a/app/Framework/Middleware/SetLocale.php
+++ b/app/Framework/Middleware/SetLocale.php
@@ -13,7 +13,7 @@ class SetLocale
     public function handle(Request $request, Closure $next): Response
     {
         $locale = $request->route('lang');
-        App::instance('route.lang', $locale);
+        App::instance('app.api.lang', $locale);
         $request->route()->forgetParameter('lang');
 
         if (!in_array($locale, ['en', 'es'])) {

--- a/app/Framework/Middleware/ValidateApiVersion.php
+++ b/app/Framework/Middleware/ValidateApiVersion.php
@@ -18,7 +18,7 @@ class ValidateApiVersion
     public function handle(Request $request, Closure $next): Response
     {
         $version = $request->route('version');
-        App::instance('route.version', $version);
+        App::instance('app.api.version', $version);
         $request->route()->forgetParameter('version');
 
         if (!in_array($version, $this->allowedVersions, true)) {


### PR DESCRIPTION
Changed the App container keys from 'route.lang' and 'route.version' to 'app.api.lang' and 'app.api.version' in SetLocale and ValidateApiVersion middleware for improved naming consistency.