### PR TITLE
Refactor permissions middleware and exception trace handling

### DIFF
--- a/app/Framework/Exceptions/UnhandledExceptions.php
+++ b/app/Framework/Exceptions/UnhandledExceptions.php
@@ -111,7 +111,7 @@ class UnhandledExceptions extends Handler
                     'exception' => get_class($e),
                     'file' => $e->getFile(),
                     'line' => $e->getLine(),
-                    'trace' => $e->getTraceAsString(),
+                    'trace' => $e->getTrace(),
                 ],
             ],
             default => [],

--- a/app/Framework/Middleware/ValidateActions.php
+++ b/app/Framework/Middleware/ValidateActions.php
@@ -17,12 +17,11 @@ class ValidateActions
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next, ...$permissions): Response
     {
         $route = $request->route();
 
         $endSession = $route?->defaults['endSession'] ?? true;
-        $permissions = $route?->defaults['permissions'] ?? [];
         $permissions = array_map('intval', $permissions);
         self::hasPermissions($permissions, $endSession);
         return $next($request);

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,17 +10,17 @@ Route::prefix('{version}/{lang}')
         Route::post('/register', [AuthController::class, 'register']);
         Route::post('/login', [AuthController::class, 'login']);
 
-        Route::middleware(['jwt', 'hasActions'])->group(function () {
+        Route::middleware(['jwt'])->group(function () {
 
             Route::prefix('user-actions')->group(function () {
-                Route::get('/user', [AuthController::class, 'getUser'])->defaults('permissions', [1, 100])->defaults('endSession', false);
-                Route::post('/logout', [AuthController::class, 'logout'])->defaults('permissions', [1, 100])->defaults('endSession', false);
-                Route::put('/user', [AuthController::class, 'updateUser'])->defaults('permissions', [1, 100])->defaults('endSession', false);
+                Route::get('/user', [AuthController::class, 'getUser'])->middleware('hasActions:1,100')->defaults('endSession', false);
+                Route::post('/logout', [AuthController::class, 'logout'])->middleware('hasActions:1,100')->defaults('endSession', false);
+                Route::put('/user', [AuthController::class, 'updateUser'])->middleware('hasActions:1,100')->defaults('endSession', false);
             });
 
             Route::prefix('default-controller')->group(function () {
-                Route::get('/response', [DefaultController::class, 'index'])->defaults('permissions', [1, 100])->defaults('endSession', false);
-                Route::get('/temp-table', [DefaultController::class, 'tempTableExample'])->defaults('permissions', [1, 100])->defaults('endSession', false);
+                Route::get('/response', [DefaultController::class, 'index'])->middleware('hasActions:1,100')->defaults('endSession', false);
+                Route::get('/temp-table', [DefaultController::class, 'tempTableExample'])->middleware('hasActions:1,100')->defaults('endSession', false);
             });
         });
     });


### PR DESCRIPTION
Updated the UnhandledExceptions handler to return exception traces as arrays instead of strings. Refactored the ValidateActions middleware to accept permissions as variadic arguments, and updated route definitions to use the 'hasActions' middleware with permission parameters instead of route defaults.