### PR TITLE
Sanitize and expose exception trace in debug

### DIFF
--- a/app/Framework/Exceptions/UnhandledExceptions.php
+++ b/app/Framework/Exceptions/UnhandledExceptions.php
@@ -106,15 +106,29 @@ class UnhandledExceptions extends Handler
             $e instanceof ValidationException => [
                 'errors' => $e->errors(),
             ],
-            $e instanceof HttpException && config('app.debug') => [
-                'debug' => [
-                    'exception' => get_class($e),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
-                ],
+            config('app.debug') => [
+                'exception' => get_class($e),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => $this->cleanTrace($e->getTrace()),
             ],
             default => [],
         };
+    }
+
+    /**
+     * Clean the trace to match Laravel's default format (without args)
+     */
+    private function cleanTrace(array $trace): array
+    {
+        return array_map(function ($frame) {
+            return array_filter([
+                'file' => $frame['file'] ?? null,
+                'line' => $frame['line'] ?? null,
+                'function' => $frame['function'] ?? null,
+                'class' => $frame['class'] ?? null,
+                'type' => $frame['type'] ?? null,
+            ], fn($value) => $value !== null);
+        }, $trace);
     }
 }

--- a/app/Framework/Middleware/FormatApiResponse.php
+++ b/app/Framework/Middleware/FormatApiResponse.php
@@ -2,8 +2,6 @@
 
 namespace App\Framework\Middleware;
 
-use App\Framework\Enums\HttpStatusCodes;
-use App\Framework\Facades\ApiResponse;
 use Illuminate\Support\Facades\Log;
 use App\Framework\Services\ApiResponseFormatterService;
 use Closure;


### PR DESCRIPTION
When app.debug is enabled, include exception debug info for all exceptions (not just HttpException) and flatten the debug payload. Add cleanTrace() to strip argument values and null fields from trace frames so the trace matches Laravel's default format and avoids leaking sensitive arg data. Also remove unused imports from FormatApiResponse middleware.