### PR TITLE
Add detailed debug data for exceptions

### DIFF
--- a/app/Framework/Exceptions/UnhandledExceptions.php
+++ b/app/Framework/Exceptions/UnhandledExceptions.php
@@ -102,18 +102,34 @@ class UnhandledExceptions extends Handler
      */
     private function getExceptionData(Throwable $e): array
     {
-        return match (true) {
-            $e instanceof ValidationException => [
-                'errors' => $e->errors(),
-            ],
-            config('app.debug') => [
-                'exception' => get_class($e),
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'trace' => $this->cleanTrace($e->getTrace()),
-            ],
-            default => [],
-        };
+        if ($e instanceof ValidationException) {
+            return ['errors' => $e->errors()];
+        }
+
+        if (!config('app.debug')) {
+            return [];
+        }
+
+        $data = [
+            'exception' => get_class($e),
+            'message' => $e->getMessage() ?: '(no message)',
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+            'code' => $e->getCode(),
+            'trace' => $this->cleanTrace($e->getTrace()),
+        ];
+
+        if ($e->getPrevious() !== null) {
+            $prev = $e->getPrevious();
+            $data['previous'] = [
+                'exception' => get_class($prev),
+                'message' => $prev->getMessage() ?: '(no message)',
+                'file' => $prev->getFile(),
+                'line' => $prev->getLine(),
+            ];
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Refactor getExceptionData to use explicit conditionals and enrich debug output. ValidationException still returns errors, non-debug mode returns an empty array, and debug mode now includes exception class, a safe message fallback, file, line, code, trace, and a summarized previous exception (if present). This provides more actionable information when app.debug is enabled.